### PR TITLE
Docker fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Environment 
 Environment , a program to speed up deployments(spawning virtual machines and configuring them for tasks) and complete basic system administrator tasks.
+This branch is configured to launch Docker and start a container(this is highly experimental(do not use this branch)/createprocess does not work in a loop). :(

--- a/linux.c
+++ b/linux.c
@@ -1,7 +1,5 @@
-
 #include <unistd.h> //For avoiding errors compiling on windows
 #include <stdio.c>
-
 void keyCheck()
 {
     const char OS[6] = {"Linux"}; //Allocate 6 spaces

--- a/main.cc
+++ b/main.cc
@@ -1,4 +1,8 @@
+//cl /EHsc test.cc
+//cl /EHsc main.cc
+//cl /EHsc /I C:\boost_1_75_0 main.cc -D_WIN32_WINNT=0x0601
     #if _WIN32
+        //#include "C:\boost_1_74_0\boost\asio.hpp"
         #include "win32.cc"
     #elif __linux__
         #include "linux.cc"
@@ -7,8 +11,10 @@
     #endif
 int main()
 {
+    
     std::string identifyHost;
     identifyHost = keyCheck();
     std::cout << identifyHost;
-    execute(); //This function will execute regardless of the host OS
+     //This function will execute regardless of the host OS
+    execute();
 }

--- a/win32.cc
+++ b/win32.cc
@@ -81,13 +81,13 @@ struct processes {
     }
     int dockerNodes() 
     {
+        const char * nodes[2]; //Alloc 3 nodes
         //Testing. I'll clean up the function later.
         //Vectors would be more efficient
-        SecureZeroMemory(&startInfo, sizeof(startInfo)); //Running a more secure version of zero memory. This function "fills a block of memeory with zeros from MSDN"
-        LPWSTR listContainers = L"docker container list"; //Fixed the error. Missing an e in exe
+        //SecureZeroMemory(&startInfo, sizeof(startInfo)); //Running a more secure version of zero memory. This function "fills a block of memeory with zeros from MSDN"
+        //LPWSTR listContainers = L"docker container list"; //Fixed the error. Missing an e in exe
         //LPWSTR nodes[2];
-        const char * nodes[2]; //Alloc 3 spaces
-        std::string start, stop, restart;
+        //std::string start, stop, restart;
         /*
         nodes[0] = L"docker container start nodeTest";
         nodes[1] = L"docker container stop nodeTest"; //Testing if both processes execute okay
@@ -141,7 +141,7 @@ void windowsTasks()
     //windowsVM.changePassword(); //Removing the default password.
     //procLaunch.createProc(); //testing test
     procLaunch.dockerLaunch();
-    std::this_thread::sleep_for (std::chrono::seconds(10)); //Wait 20 seconds for Docker desktop to start. This pauses the current thread this program(variant) is designed to be launched at startup
+    std::this_thread::sleep_for (std::chrono::seconds(30)); //Wait 20 seconds for Docker desktop to start. This pauses the current thread this program(variant) is designed to be launched at startup
     procLaunch.dockerNodes();
     //procLaunch.dockerList();
 }

--- a/win32.cc
+++ b/win32.cc
@@ -85,12 +85,21 @@ struct processes {
         //Vectors would be more efficient
         SecureZeroMemory(&startInfo, sizeof(startInfo)); //Running a more secure version of zero memory. This function "fills a block of memeory with zeros from MSDN"
         LPWSTR listContainers = L"docker container list"; //Fixed the error. Missing an e in exe
-        LPWSTR nodes[2];
+        //LPWSTR nodes[2];
+        const char * nodes[2]; //Alloc 3 spaces
         std::string start, stop, restart;
+        /*
         nodes[0] = L"docker container start nodeTest";
         nodes[1] = L"docker container stop nodeTest"; //Testing if both processes execute okay
         nodes[2] = L"docker container start nodeTest"; //does not loop well.
-        CreateProcess(L"C:\\Program Files\\Docker\\Docker\\resources\\docker.exe",nodes[0],NULL,NULL,FALSE, 0,NULL,NULL,&startInfo,&procInfo);
+        */
+        nodes[0] = "docker container start nodeTest";
+        nodes[1] = "docker container stop nodeTest"; //Testing if both processes execute okay
+        nodes[2] = "docker container start nodeTest"; //does not loop well.
+        //CreateProcess(L"C:\\Program Files\\Docker\\Docker\\resources\\docker.exe",nodes[0],NULL,NULL,FALSE, 0,NULL,NULL,&startInfo,&procInfo);
+        std::system(nodes[0]);
+        std::system(nodes[1]);
+        std::system(nodes[2]);
         //CreateProcess(L"C:\\Program Files\\Docker\\Docker\\resources\\docker.exe",nodes[1],NULL,NULL,FALSE, 0,NULL,NULL,&startInfo,&procInfo);
         //CreateProcess(L"C:\\Program Files\\Docker\\Docker\\resources\\docker.exe",nodes[2],NULL,NULL,FALSE, 0,NULL,NULL,&startInfo,&procInfo);
         /*
@@ -132,7 +141,7 @@ void windowsTasks()
     //windowsVM.changePassword(); //Removing the default password.
     //procLaunch.createProc(); //testing test
     procLaunch.dockerLaunch();
-    std::this_thread::sleep_for (std::chrono::seconds(20)); //Wait 20 seconds for Docker desktop to start. This pauses the current thread this program(variant) is designed to be launched at startup
+    std::this_thread::sleep_for (std::chrono::seconds(10)); //Wait 20 seconds for Docker desktop to start. This pauses the current thread this program(variant) is designed to be launched at startup
     procLaunch.dockerNodes();
     //procLaunch.dockerList();
 }

--- a/win32.hpp
+++ b/win32.hpp
@@ -1,0 +1,14 @@
+// typedef const wchar_t *LPCWSTR; = LPCWSTR which is required(netuserchangepassword function)
+//https://docs.microsoft.com/en-us/cpp/cpp/char-wchar-t-char16-t-char32-t?view=vs-2019
+#ifndef UNICODE
+#define UNICODE
+#endif
+#pragma comment(lib, "netapi32.lib")
+#include <windows.h> //Windows header
+#include <cstdio> //C function
+#include <iostream> //standard library
+#include <lm.h> //nstatus
+#include <Processthreadsapi.h> //Create proccess
+#include <Errhandlingapi.h> //Error handling
+#include <chrono> //Timer
+#include <thread> //Timer


### PR DESCRIPTION
Environment now launches Docker with CreateProcessA and starts/stops containers with std::system. Launching multiple CreateProcessA(attempting to control containers) led to unexpected behavior.